### PR TITLE
HRC Txings update

### DIFF
--- a/HRC_TXING_CHECK/HRC_Txing_Check.py
+++ b/HRC_TXING_CHECK/HRC_Txing_Check.py
@@ -14,10 +14,10 @@ import apt_date_secs as apt
 import Backstop_File_Processing as bfp
 import Calc_Delta as cd
 
-import Insert_Comment_In_ALR as icia
+#import Insert_Comment_In_ALR as icia
+exec(open("/home/gregg/UTILITIES/LR_CODE/Insert_Comment_In_ALR_V2.0.py").read())
 
 import ORP_File_Class as ofc
-import OFLS_File_Utilities as oflsu
 
 """
 The basic structure of an SI mode command sequence is:
@@ -57,7 +57,7 @@ determine that a storm is bad enough to trigger a shutdown.
 hrc_txing_parser = argparse.ArgumentParser()
 
 # Path to the ofls directory
-hrc_txing_parser.add_argument("review_load_path", help="Path to the Review load directory. e.g. /data/acis/LoadReviews/2022/FEB2122/ofls'")
+hrc_txing_parser.add_argument("review_load_path", help="Path to the Review load directory. e.g. /data/acis/LoadReviews/2022/FEB2122/ofls")
 
 # Add the TEST argument as NON-POSITIONAL.  
 hrc_txing_parser.add_argument("-t", "--test", help="In test mode", action="store_true")
@@ -96,6 +96,16 @@ rev_load_commands = BSC.Read_Review_Load(BSC.outdir)
 rev_start_date = rev_load_commands[0]['date']
 rev_start_time = rev_load_commands[0]['time']
 
+# Initialize the stop science date and time to the load start date/time
+# That way when one of the tests below executes early on because of a really
+# messed up load  and uses those times there is SOME value in the variables.
+stop_science_date = rev_start_date
+stop_science_time = rev_start_time
+
+# Two flags indicating that SCS-134 was activated and that it is still running
+hrc_activated_flag = False
+hrc_running_flag = False
+
 # Calculate a tbegin time such that you will backchain one Continuity load.
 # 50 hours will be enough - you want to capture any Event History activation
 # that may have occurred
@@ -116,21 +126,23 @@ extracted_cmds = np.array([], dtype = assembled_commands.dtype)
 for eachcmd in assembled_commands:
     # Test to see if this is one of the commands we want to keep
     if ("ACISPKT" in eachcmd["commands"]) or \
-       ("COACTS1=134" in eachcmd["commands"]):
+       ("COACTS1=134" in eachcmd["commands"]) or \
+       ("215PCAOF" in eachcmd["commands"]):
         new_row = np.array( [ (eachcmd["commands"],
                                              eachcmd["time"],
                                              eachcmd["date"]) ], dtype = BSC.CR_DTYPE)
         
         extracted_cmds =  np.append(extracted_cmds, new_row, axis=0)
 
-
 # Initialize the event histogram found flag to False
-evh_found_flag = False
+evh_loaded_flag = False
     
 # Now step through the array and look for any command which contains one of  the
 # parameter block WT commands that are presently used for HRC observation
 # Event Histograms.
 for index, each_cmd in enumerate(extracted_cmds):
+    # EVENT HISTOGRAM LOAD
+    # Detect if we are loading one of the two Event Histograms used when HRC is observing.
     # If any Event History WT packet name exists in this backstop command,
     # save it.  Otherwise the list will be empty
     key_list = [eachkey  for eachkey in ev_parameter_block_dict.keys() if eachkey in each_cmd["commands"]  ]
@@ -138,9 +150,9 @@ for index, each_cmd in enumerate(extracted_cmds):
     # If  one of the HRC Event Histogram SI modes parameter blocks appears in this
     # command line but we already found an Event Histogram but have not yet seen
     # its corresponding SCS-134 activation command, we found an error
-    if key_list and (evh_found_flag == True):
-        # We foung an error. Place an error statement in the comments list, and print it out for the log file.
-        full_comment = " ".join((">>> ERROR -", each_cmd["date"], "Multiple Event Histogram SI Mode loads without an intervening SCS-134 activation"))
+    if key_list and (evh_loaded_flag == True):
+        # ERROR -  Place an error statement in the comments list, and print it out for the log file.
+        full_comment = " ".join((each_cmd["date"], "\n>>> ERROR -", each_cmd["date"], "Multiple Event Histogram SI Mode loads without an intervening SCS-134 activation"))
         print("\n", full_comment)
         # Append the comment to the comment list
         comment_list.append([each_cmd["date"], each_cmd["time"], full_comment])
@@ -152,17 +164,17 @@ for index, each_cmd in enumerate(extracted_cmds):
 
     # Else if this is the first Event Histogram SI Mode load since the start of
     # the load or the first since the last EV Load/SCS-134 activation pair.
-    elif key_list and (evh_found_flag == False):
+    elif key_list and (evh_loaded_flag == False):
         
+        # You have found one of the event histogram modes used during an HRC science observation
+        # Set the Event History SI mode found flag to True
+        evh_loaded_flag = True
+     
         # Calculate the index of the first start science command in the SI mode load
         first_start_science_index = index - 6
 
         # Calculate the required delta t given the SI mode bias time
         required_dt = ev_parameter_block_dict[key_list[0]] + 1152.0
-        
-        # You have found one of the event histogram modes used during an HRC science observation
-        # Set the Event History SI mode found flag to True
-        evh_found_flag = True
          
         # The next step is to find the corresponding COACTS1=134 command that subsequently
         # appears in the load.  This will allow you to calculate the time delta between the start
@@ -171,67 +183,187 @@ for index, each_cmd in enumerate(extracted_cmds):
         # Record the start date and time of the first command in the SI mode load
         bias_start_date = extracted_cmds[index - 6]["date"]
         bias_start_time = extracted_cmds[index - 6]["time"]
+        
+    # If this is an ACISPKT command and a  parameter block load command
+    # (starts with WT) but not one of the two Event Histogram modes used when
+    # HRC is observing, then you are loading some other SI mode which
+    # "overwrites" whatever the active SI mode is. So set the loaded flag to False.
+    if (not key_list) and \
+       ("ACISPKT" in each_cmd["commands"]) and \
+       ("TLMSID= WT" in each_cmd["commands"]):
+        evh_loaded_flag = False
 
+    # XTZ0000005 - and an Event Histogram SI mode loaded . Signal that the
+    # Event Histogram has started.
+    if ("XTZ0000005" in  each_cmd["commands"]) and (evh_loaded_flag == True):
+        event_hist_running = True;
+
+    # XTZ0000005 - Event Histogram SI mode NOT loaded 
+    elif ("XTZ0000005" in  each_cmd["commands"]) and (evh_loaded_flag == False):
+        event_hist_running = False;
+
+    # COACTS1=134 - HRC Observation begins.
+    # ERROR - Event Histogram never loaded
     # Else you see an SCS-134 activation but you have NOT seen the Event Histogram
     # load that should have come prior to this command.  This is an error. Add an error
     # comment, and print it out for the log file. This will catch all errors of this type if there
     # are one or more HRC observations in the load.
-    elif ("COACTS1=134" in each_cmd["commands"]) and \
-         ( evh_found_flag == False):
+    if ("COACTS1=134" in each_cmd["commands"]) and \
+         ( evh_loaded_flag == False):
+
+        # Set the hrc activated and running flags to True
+        hrc_running_flag = True
+        hrc_activated_flag = True
         
-       # Write the SCS-134 activation information line
-        scs134_act_string =  each_cmd["date"] + " SCS-134 Activation"
+       # Create the SCS-134 activation information line
+        scs134_act_string =  each_cmd["date"] + " SCS-134 Activation: HRC Observation Begun"
+
+        # Create the error string telling the reviewer that no EVHIST SI mode was loaded
+        error_comment = " ".join((scs134_act_string, "\n>>> ERROR - Event Histogram SI Mode Load never loaded prior to an SCS-134 activation"))
+        # Print it for the log file
+        print("\n", error_comment)
         
-        full_comment = " ".join(("\n", scs134_act_string, "\n>>> ERROR - SCS-134 activation without a prior Event Histogram SI Mode Load"))
-        print("\n", full_comment)
         # Append the comment to the comment list
-        comment_list.append([each_cmd["date"], each_cmd["time"], full_comment])
+        comment_list.append([each_cmd["date"], each_cmd["time"], error_comment])
+
+    # ERROR - Event Histogram not running
+    # HRC START command but the Event Histogram is NOT running. Give a grace
+    # period of one second to account for time calculation accuracies.It may not happen the same way next time. 
+    elif ("COACTS1=134" in each_cmd["commands"]) and \
+         ( event_hist_running == False):
+        
+        # Set the hrc activated and running flags to True
+        hrc_running_flag = True
+        hrc_activated_flag = True
+         
+        # Create a string to record the SCS-134 activation date 
+        scs134_act_string =  each_cmd["date"] + " SCS-134 Activation: HRC Observation Begun"
+        
+        # Calculate the time between the start of SI mode load and the activation of
+        # SCS-134. Even though we've detected that the EVHIST is not running, we also
+        # need to check that the timing between SI mode load and SCS-134 activation is correct.
+        delta_t = round(each_cmd["time"] - bias_start_time, 2)
+        
+        # Check to see if the time is long enough and write the corresponding comment.
+        # Create the delta t comment either way.
+        if delta_t < required_dt:
+            # ERROR - Time delta is not long enough
+            delta_t_comment = " ".join((scs134_act_string, "\n>>> ERROR - Time between SI mode load start and SCS-134 activation is too short\n            SI Mode Load Start: ", bias_start_date, "\n     SCS-134 Activation: ", each_cmd["date"], "\n     Required Delta T:", str(required_dt), "        Actual Delta T:" , str(delta_t)))
+            
+            # Print the error comment for the log file
+            print("\n", delta_t_comment)
+            
+        else: # The time delta is long enough
+            delta_t_comment = " ".join((scs134_act_string, "\n      Time between SI Mode load start and SCS-134 activation is good: \n     Required Delta T:", str(required_dt), "       Actual Delta T:" , str(delta_t)))
+
+        # Append the delta t comment comment to the comment list
+        comment_list.append([each_cmd["date"], each_cmd["time"], delta_t_comment])
+
+        # Now here is the error statement due to the fact that the EVHIST is not running.
+        error_comment = " ".join((scs134_act_string, "\n>>> ERROR - SCS-134 activated but Event Histogram not running"))
+        
+        # Print the error out for the log file
+        print("\n", error_comment)
+        # Append the comment to the comment list
+        comment_list.append([each_cmd["date"], each_cmd["time"], error_comment])
         
     # Else, if you have found an Event Histogram Mode used for HRC observations
     # and this command is the corresponding SCS-134 activation, you can calculate
     # the delta time
     elif ("COACTS1=134" in each_cmd["commands"]) and \
-         ( evh_found_flag == True):
-
+         ( evh_loaded_flag == True) and \
+         (event_hist_running == True):
+        
+        # Set the hrc activated and running flags to True
+        hrc_running_flag = True
+        hrc_activated_flag = True
+ 
         # Calculate the time between the start of SI mode load and the activation of
         # SCS-134
         delta_t = round(each_cmd["time"] - bias_start_time, 2)
   
         # Write the SCS-134 activation information line
-        scs134_act_string =  each_cmd["date"] + " SCS-134 Activation"
-        
+        scs134_act_string =  each_cmd["date"] + " SCS-134 Activation: HRC Observation Begun"
+
         # Check to see if the time is long enough and write the corresponding comment.
         if delta_t < required_dt:
             # ERROR - Time delta is not long enough
-            full_comment = " ".join((scs134_act_string, "\n",">>> ERROR - Time between SI mode load start and SCS-134 activation is too short\n     SI Mode Load Start: ", bias_start_date, "\n     SCS-134 Activation: ", each_cmd["date"], "\n     Required Delta T:", str(required_dt), "        Actual Delta T:" , str(delta_t)))
+            full_comment = " ".join((scs134_act_string, "\n>>> ERROR - Time between SI mode load start and SCS-134 activation is too short\n     SI Mode Load Start: ", bias_start_date, "\n     SCS-134 Activation: ", each_cmd["date"], "\n     Required Delta T:", str(required_dt), "        Actual Delta T:" , str(delta_t)))
             print("\n",full_comment)
             
         else: # The time delta is long enough
-            full_comment = " ".join((scs134_act_string, "\n", "    Time between SI Mode load start and SCS-134 activation is good: \n     Required Delta T:", str(required_dt), "       Actual Delta T:" , str(delta_t)))
+            full_comment = " ".join((scs134_act_string, "\n    Time between SI Mode load start and SCS-134 activation is good: \n     Required Delta T:", str(required_dt), "       Actual Delta T:" , str(delta_t)))
 
         # Append the comment to the comment list
         comment_list.append([each_cmd["date"], each_cmd["time"], full_comment])
-        
-        # Set the evh_found_flag to False so that you can find the next SI mode load.
-        evh_found_flag = False
-        
-# Done scanning all the commands in the load. In a legal load, where each HRC Event Histogram SI mode
-# load is paired with an SCS-134 activation,   evh_found_flag == False at this point.
-# So if you get to this point and evh_found_flag == True, then there exists an Event Histogram load 
-# which has no corresponding scs-134 activation.  This check handles the case where there
-# was only one HRC science observation in the load but the SCS-134 activation is missing.
-if evh_found_flag == True:
-    # ERROR - One of the HRC Event Histograms were loaded but there was never a corresponding SCS-134 activation
-    full_comment = " ".join(("\n",">>> ERROR - HRC Observation Event Histogram SI mode was loaded at but SCS-134 was not activated.\n     SI Mode Load Start: ", bias_start_date))
-    print("\n",full_comment)
 
-    # Append the comment to the comment list
-    comment_list.append([bias_start_date, bias_start_time, full_comment])
+    # AA00000000 - No matter what ACIS SI mode is loaded this command stops the
+    #                         clocking. And if an HRC Event Histogram is running that gets
+    #                         stopped too. So there's no need to differentiate between one of
+    #                         the two Event Histograms or any other.
+    if  ("AA00000000" in  each_cmd["commands"]):
+        event_hist_running = False
+        stop_science_date = each_cmd["date"]
+        stop_science_time = each_cmd["time"]
+        
+    # 215PCAOF - HRC Observation complete.
+    if ("215PCAOF" in  each_cmd["commands"]):
+        # Create the string that indicates the HRC obs 15V power down command issued.
+        HRC_shutdown_string = each_cmd["date"] + " 215PCAOF command: HRC Observation Ends"
+        
+        # Now check to see if the event histogram was running at this point of
+        # the load. Several situations have to be covered:
+        #
+        #    1) The 215PCAOF comes before the EVHIST stop science (i.e. EVHIST
+        #        still running) - always OK.
+        #
+        #    2) SCS-134 was never activated - ERROR because if you are stopping HRC you
+        #        must have expected that it was started
+        #
+        #    3) The EVHIST stop science comes before the 215PCAOF command
+        #         -  Delta t between the  AA00 and 215PCAOF commands <= 1 second - OK
+        #         -  Delta t between the  AA00 and 215PCAOF commands > 1 second - NOT OK
+        #                - See Guideline
+        #
+        #
+        #
+        # Possibility #1 - EVHIST still running
+        if event_hist_running == True:
+            comment_list.append([each_cmd["date"], each_cmd["time"], HRC_shutdown_string])
+            
+        # Possibility #2 - Check to see if the SCS-134 activation ever occurred
+        elif hrc_activated_flag == False:
+            HRC_activation_error_string = " ".join((HRC_shutdown_string, "\n>>> ERROR - SCS-134  was never activated"))
+            print("\n", HRC_activation_error_string)
+            comment_list.append([each_cmd["date"], each_cmd["time"], HRC_activation_error_string])
+
+        # Possibility #3  - EVHIST loaded, run, and was shut down prior to 215PCAOF
+        elif (evh_loaded_flag == True) and \
+              (event_hist_running == False):
+            # Calculate the detla t between the EVHIST shutdown and this 215PCAOF command
+            delta_t = each_cmd["time"]  -  stop_science_time
+
+            # If delta t is one second or less, then the EVHIST was shut down closely enough
+            # to this HRC shutdown to nor risk the HRC
+            if delta_t <= 1:
+                # Good shutdown timing with regard to the AA00000000. Record the
+                # shutdown time.
+                comment_list.append([each_cmd["date"], each_cmd["time"], HRC_shutdown_string])
+            else: # HRC was running too long past the EVHIST stop science
+                HRC_shutdown_error_string = " ".join((HRC_shutdown_string, "\n>>> ERROR - The Event Histogram was shut down more than 1 second prior to  the time of HRC shutdown"))
+                print("\n", HRC_shutdown_error_string)
+                comment_list.append([each_cmd["date"], each_cmd["time"], HRC_shutdown_error_string])
  
+        # HRC is not running so set the HRC running flag to false. And set the
+        # activated flag to False since this command de-activates it.
+        hrc_running_flag = False
+        hrc_activated_flag = False
+
 
 # Done finding all HRC Txing delta t's. If there are lines in the comment_list, insert
 # them in a copy of ACIS_LoadReview.txt called ACIS_LoadReview.txt.TXING_COMMENT
 if len(comment_list)> 0:
+    # There are comments - insert them
     icia.Insert_Comment_In_ALR(comment_list, load_week_path, "HRC_TXING")
 
     # Copy the updated ACIS-LoadReview.txt file
@@ -254,4 +386,3 @@ if len(comment_list)> 0:
 else:
     print(">>> Warning - No Event Histogram/SCS-134 Activation pairs found in this load.")
 
-    

--- a/HRC_TXING_CHECK/HRC_Txing_Check.py
+++ b/HRC_TXING_CHECK/HRC_Txing_Check.py
@@ -134,7 +134,7 @@ for eachcmd in assembled_commands:
         
         extracted_cmds =  np.append(extracted_cmds, new_row, axis=0)
 
-# Initialize the event histogram found flag to False
+# Initialize the event histogram loaded flag to False
 evh_loaded_flag = False
     
 # Now step through the array and look for any command which contains one of  the

--- a/Release_Notes_V4.4.txt
+++ b/Release_Notes_V4.4.txt
@@ -30,7 +30,7 @@ Additional small changes to lr were made to remove extraneous print
 statements and fix a typo in a print statement.
 
 To support  Find_Idle_Dwells.py, the following utility programs were
-added:
+updated or added:
 
 	 UTILITIES/Backstop_File_Processing.py
 	 UTILITIES/Insert_Comment_In_ALR.py

--- a/Release_Notes_V4.5.txt
+++ b/Release_Notes_V4.5.txt
@@ -1,0 +1,77 @@
+Change Description
+==================
+
+Additional tests were added to HRC_Txing_Check.py based upon the FEB0623T Test load.
+These new tests include: missing SCS-134 activation, the command to end the HRC
+observation occurs well after the ACIS Event Histogram Stop Science, and the ACIS
+Event Histogram is never activated.  In addition the program structure was simplified
+and an extraneous import eliminated.
+
+In addition, Insert_Comment_In_ALR.py was slightly modified in order to
+account for a corner case when inserting comments into the ACIS-LoadReview.txt file.
+
+In both cases comments were updated and improved.
+
+
+Files Changed or added:
+=======================
+
+
+The updates can be seen here:
+
+https://github.com/acisops/lr/pull/
+
+Testing:
+======== 
+
+Both unit and regression testing were carried out for each of the two programs.
+
+Unit tests for  HRC_Txings_Check.py were carried out by running those programs on the
+regression test loads (see below) independently from the ACIS load review program.
+The output was checked against expected outputs.  Then regression tests were carried
+out by running the updated program from the ACIS load review program and the results
+checked to be sure they were correct and complete.
+
+Unit tests for Insert_Comment_In_ALR.py were carried out by generating a list of comments
+to be inserted in an ACIS-LoadReview.txt file and the resultant file checked for proper placement.
+Output from the Check_Power, Window_Check, Idle Dwell and HRC-Txing Checks on all regression
+tests confirmed that  Insert_Comment_In_ALR.py executes corectly.
+
+The changes were tested by running these regression test loads:
+
+
+DEC0522P - First HRC-Txings Test Load
+
+DEC0522F,G,H - Created by ACIS Ops
+                           DEC0522P backstop file was hand modified to test error handling
+                           when an HRC Observation Event Histogram SI mode was loaded,
+		           but an SCS-134 activation is missing or if an SCS-134 activation
+		           occurred but no Event Histogram SI mode was previously loaded.
+			   
+JAN3023A - Production load with no HRC commanding
+
+JAN3023T - Second HRC-Txings Test Load
+
+FEB0623T - Third HRC-Txings Test load
+
+All tests passed.
+
+
+
+Interface impacts
+=================
+
+None
+
+
+Review
+====== 
+
+ACIS Ops
+
+
+Deployment Plan
+===============
+
+Will be deployed after FSDS approval.
+

--- a/Release_Notes_V4.5.txt
+++ b/Release_Notes_V4.5.txt
@@ -19,7 +19,7 @@ Files Changed or added:
 
 The updates can be seen here:
 
-https://github.com/acisops/lr/pull/
+https://github.com/acisops/lr/pull/37
 
 Testing:
 ======== 

--- a/UTILITIES/Insert_Comment_In_ALR.py
+++ b/UTILITIES/Insert_Comment_In_ALR.py
@@ -28,11 +28,8 @@ def Insert_Comment_In_ALR( comment_list, ALR_path, extension = "COMMENTS"):
     
     output: updated_ALR_file 
                  - An updated file located in ALR_path with the inserted comments
-          
-                   
     
     """
-    
     # Path to the ACIS-LoadReview.txt file to be modified.
     ALR_file_path = os.path.join(ALR_path, "ACIS-LoadReview.txt")
     
@@ -64,19 +61,20 @@ def Insert_Comment_In_ALR( comment_list, ALR_path, extension = "COMMENTS"):
     # Now for each comment in the comments list, find the two indices
     # between which the comment must fall based on time stamp
     for each_comment in comment_list:
-        # Find all the times in the event_times list that are LEQ  the comment time in question
+        # Find the indices of all the times in the event_times list that are LEQ  the
+        # comment time in question
         leq_times = [index for index, etime in enumerate(event_times) if etime <= each_comment[1]]
         
         # Now the last value in the leq_times list is the index into
         # time_stamped_line_indices where you will obtain the location
         # in the ALR list of where you want to insert the comment text
-        insert_loc = time_stamped_line_indices[leq_times[-1] +1]
-
+        insert_loc = time_stamped_line_indices[leq_times[-1]] +1
+        
         # At long last you now know where to insert the comment text
         # It's before insert_loc
         # Write the date (DOY) and the comment statement
         ALR_lines.insert(insert_loc, "".join(("\n",  each_comment[2], "\n\n")) )
-    
+
         # Since you've added lines, you have to re-calculate the indices of all those
         # lines which begin with a DOY time stamp again.
         # This is the position of the stamped line in the ALR file.


### PR DESCRIPTION
Additional tests were added to HRC_Txing_Check.py based upon the FEB0623T Test load.
These new tests include: missing SCS-134 activation, the command to end the HRC
observation occurs on or before the ACIS Event Histogram Stop Science, and the ACIS
Event Histogram is never activated.  In addition the program structure was simplified
and an extraneous import eliminated.

In addition, Insert_Comment_In_ALR.py was slightly modified in order to
account for a corner case when inserting comments into the ACIS-LoadReview.txt f
ile.

In both cases comments were updated and improved.
