### PR TITLE
Updates to ACIS Load Review software and utilites

### DIFF
--- a/HETG_CHECK/HETG_Check.py
+++ b/HETG_CHECK/HETG_Check.py
@@ -55,12 +55,12 @@ import OFLS_File_Utilities as oflsu
 #
 # Parse the input arguments
 #
-deadman_parser = argparse.ArgumentParser()
-deadman_parser.add_argument("review_load_path", help="Path to the Review load directory. e.g. /data/acis/LoadReviews/2022/FEB2122/ofls'")
+hetg_parser = argparse.ArgumentParser()
+hetg_parser.add_argument("review_load_path", help="Path to the Review load directory. e.g. /data/acis/LoadReviews/2022/FEB2122/ofls'")
 
-deadman_parser.add_argument("nlet_file_path", help="Path to the NLET file to be used in assembling the history. e.g. /data/acis/LoadReviews/TEST_NLET_FILES/FEB2122A_NonLoadTrackedEvents.txt")
+hetg_parser.add_argument("nlet_file_path", help="Path to the NLET file to be used in assembling the history. e.g. /data/acis/LoadReviews/TEST_NLET_FILES/FEB2122A_NonLoadTrackedEvents.txt")
 
-args = deadman_parser.parse_args()
+args = hetg_parser.parse_args()
 
 #
 # Inits
@@ -251,6 +251,11 @@ for each_cmd in assembled_commands:
                 HETG_in_length = cd.Calc_Delta_Time(HETG_in_date, HETG_out_date)
                 percent_in = HETG_in_length[0]/radzone_length[0] * 100.0
                 print('          Percent time the HETG was in for this Perigee Passage: %.2f' % (percent_in),'%')
+                # Also calculate the amount of time between the HETG Retraction and OORMPEN
+                time_hetg_out = cd.Calc_Delta_Time(HETG_out_date , OORMPEN_date)
+                # ...and display that for the user
+                print("          The HETG retraction began %.2f hours or %.2f minutes prior to RADMON EN" % (time_hetg_out[2], time_hetg_out[1]))
+                
             elif (radzone_length[0] > 0.0) and \
                  (HETG_status == 'IN'):
                 # But if the HETG is still in, calculate the percentage using the OORMPEN time

--- a/Release_Notes_V4.6.txt
+++ b/Release_Notes_V4.6.txt
@@ -34,7 +34,7 @@ Files Changed or added:
 
 The updates can be seen here:
 
-https://github.com/acisops/lr/pull/?????
+https://github.com/acisops/lr/pull/38
 
 Testing:
 ======== 

--- a/Release_Notes_V4.6.txt
+++ b/Release_Notes_V4.6.txt
@@ -8,7 +8,7 @@ HETG_Check.py:
 
 When nearing the perigee passage, the SIM is moved to put the ACIS instrument under cover.
 To protect ACIS against a failed SIM move, the HETG is required to be inserted for the Perigee Passage.
-HETG_Check.py is run during a load review to show the reviewer the RADMON DISABLE, HETG isertion/retraction,
+HETG_Check.py is run during a load review to show the reviewer the RADMON DISABLE, HETG insertion/retraction,
 and RADMON ENABLE times for the perigee passage.  HETG_Check.py was modified such that if, during a perigee passage,
 the HETG is retracted before RADMON ENABLE (OOPRMEN), the program will print an additional statement which displays
 the time delta between the retraction command and OORMPEN in both hours and minutes. This is to aid the reviewer in
@@ -17,7 +17,7 @@ determining if the HETG has been retracted too soon.
 HRC_Txing_Check.py:
 
 The purpose of HRC_Txing_Check.py is to check the timing of ACIS and HRC commands during HRC science
-observations and determine if any guideline has been violated.  When an ACIS CC mode observation is
+observations and determine if any guideline has been violated.  When an ACIS CC mode observation appears
 between two HRC observations, the program threw a false error.  This update eliminates the false error.
 Opportunity was also taken to improve some variable names and comments.
 
@@ -39,7 +39,7 @@ https://github.com/acisops/lr/pull/38
 Testing:
 ======== 
 
-Both unit and regression testing were carried out for each of the two programs.
+Both unit and regression testing were carried out for each of the three  programs.
 
 Unit tests for  HRC_Txings_Check.py and HETG_Check.py were carried out by
 running those programs on the regression test loads (see below) independently

--- a/Release_Notes_V4.6.txt
+++ b/Release_Notes_V4.6.txt
@@ -50,7 +50,7 @@ ACIS load review program and the results checked to be sure they were correct an
 Unit tests for Insert_Comment_In_ALR.py were carried out by generating a list of comments
 to be inserted in an ACIS-LoadReview.txt file and the resultant file checked for proper placement.
 Output from the Check_Power, Window_Check, HETG_Check,  Idle Dwell and HRC-Txing Checks on all regression
-tests confirmed that  Insert_Comment_In_ALR.py executes corectly.
+tests confirmed that  Insert_Comment_In_ALR.py executes correctly.
 
 The changes were tested by running these regression test loads:
 

--- a/Release_Notes_V4.6.txt
+++ b/Release_Notes_V4.6.txt
@@ -1,0 +1,86 @@
+Change Description
+==================
+
+This update includes changes to two Load Review check programs (HETG_Check.py and HRC_Txing_Check.py)
+and one utility program that is used by those programs (Insert_Comment_In_ALR.py).
+
+HETG_Check.py:
+
+When nearing the perigee passage, the SIM is moved to put the ACIS instrument under cover.
+To protect ACIS against a failed SIM move, the HETG is required to be inserted for the Perigee Passage.
+HETG_Check.py is run during a load review to show the reviewer the RADMON DISABLE, HETG isertion/retraction,
+and RADMON ENABLE times for the perigee passage.  HETG_Check.py was modified such that if, during a perigee passage,
+the HETG is retracted before RADMON ENABLE (OOPRMEN), the program will print an additional statement which displays
+the time delta between the retraction command and OORMPEN in both hours and minutes. This is to aid the reviewer in
+determining if the HETG has been retracted too soon.
+
+HRC_Txing_Check.py:
+
+The purpose of HRC_Txing_Check.py is to check the timing of ACIS and HRC commands during HRC science
+observations and determine if any guideline has been violated.  When an ACIS CC mode observation is
+between two HRC observations, the program threw a false error.  This update eliminates the false error.
+Opportunity was also taken to improve some variable names and comments.
+
+Insert_Comment_In_ALR.py:
+
+This utility program is used to insert comments/error statements in the ACIS-LoadReview.txt file - an output file
+of the ACIS load review.  The program was failing when a comment or error statement to be inserted has the exact same
+time stamp as the last time stamped output line already in the ACIS-LoadReview.txt file. This update fixed that error.
+
+
+Files Changed or added:
+=======================
+
+
+The updates can be seen here:
+
+https://github.com/acisops/lr/pull/?????
+
+Testing:
+======== 
+
+Both unit and regression testing were carried out for each of the two programs.
+
+Unit tests for  HRC_Txings_Check.py were carried out by running those programs on the
+regression test loads (see below) independently from the ACIS load review program.
+The output was checked against expected outputs.  Then regression tests were carried
+out by running the updated program from the ACIS load review program and the results
+checked to be sure they were correct and complete.
+
+Unit tests for Insert_Comment_In_ALR.py were carried out by generating a list of comments
+to be inserted in an ACIS-LoadReview.txt file and the resultant file checked for proper placement.
+Output from the Check_Power, Window_Check, HETG_Check,  Idle Dwell and HRC-Txing Checks on all regression
+tests confirmed that  Insert_Comment_In_ALR.py executes corectly.
+
+The changes were tested by running these regression test loads:
+
+
+ JUL0323
+
+ JUL2423
+
+DEC0522F,G,H - Hand created by ACIS Ops to purposefully introduce errors into the loads.
+			   
+JAN3023A - Production load with no HRC commanding
+
+All tests passed.
+
+
+
+Interface impacts
+=================
+
+None
+
+
+Review
+====== 
+
+ACIS Ops
+
+
+Deployment Plan
+===============
+
+Will be deployed after FSDS approval.
+

--- a/Release_Notes_V4.6.txt
+++ b/Release_Notes_V4.6.txt
@@ -41,11 +41,11 @@ Testing:
 
 Both unit and regression testing were carried out for each of the two programs.
 
-Unit tests for  HRC_Txings_Check.py were carried out by running those programs on the
-regression test loads (see below) independently from the ACIS load review program.
-The output was checked against expected outputs.  Then regression tests were carried
-out by running the updated program from the ACIS load review program and the results
-checked to be sure they were correct and complete.
+Unit tests for  HRC_Txings_Check.py and HETG_Check.py were carried out by
+running those programs on the regression test loads (see below) independently
+from the ACIS load review program. The output was checked against expected outputs.
+Then regression tests were carried out by running the updated program from the
+ACIS load review program and the results checked to be sure they were correct and complete.
 
 Unit tests for Insert_Comment_In_ALR.py were carried out by generating a list of comments
 to be inserted in an ACIS-LoadReview.txt file and the resultant file checked for proper placement.


### PR DESCRIPTION
This update includes changes to two Load Review check programs (HETG_Check.py and HRC_Txing_Check.py)
and one utility program that is used by those programs (Insert_Comment_In_ALR.py).


HETG_Check.py:

When nearing the perigee passage, the SIM is moved to put the ACIS instrument under cover.
To protect ACIS against a failed SIM move, the HETG is required to be inserted for the Perigee Passage.
HETG_Check.py is run during a load review to show the reviewer the RADMON DISABLE, HETG isertion/retraction,
and RADMON ENABLE times for the perigee passage.  HETG_Check.py was modified such that if, during a perigee passage,
the HETG is retracted before RADMON ENABLE (OOPRMEN), the program will print an additional statement which displays
the time delta between the retraction command and OORMPEN in both hours and minutes. This is to aid the reviewer in
determining if the HETG has been retracted too soon.

HRC_Txing_Check.py:

The purpose of HRC_Txing_Check.py is to check the timing of ACIS and HRC commands during HRC science
observations and determine if any guideline has been violated.  When an ACIS CC mode observation is
between two HRC observations, the program threw a false error.  This update eliminates the false error.
Opportunity was also taken to improve some variable names and comments.

Insert_Comment_In_ALR.py:

This utility program is used to insert comments/error statements in the ACIS-LoadReview.txt file - an output file
of the ACIS load review.  The program was failing when a comment or error statement to be inserted has the exact same
time stamp as the last time stamped output line already in the ACIS-LoadReview.txt file. This update fixed that error.

