### PR TITLE
1DPAMYT model addition; Automated Continmuity File Adjustment

### DIFF
--- a/Adjust_ACIS-Continuity.py
+++ b/Adjust_ACIS-Continuity.py
@@ -1,0 +1,130 @@
+
+import argparse
+import shutil
+
+import apt_date_secs as apt
+#import BackstopCommandsClass
+from backstop_history import BackstopHistory
+"""
+Adjust_ACIS-Continuity.py - LR has determined that a continuity load was reviewed as a full load,
+                                              but was uplinked and run VEHICLE ONLY because the load prior to
+                                              the Continuity load was interrupted by either a 107-only or a
+                                              Full Stop AFTER the Continuity load was reviewed and approved.
+
+                                              Therefore the Continuity load's ACIS-Continuity.txt file needs to
+                                              be updated with the interrupt type and the time of interrupt. This
+                                              information is available in the NLET file.
+
+                                              Also important is the fact that this adjustment need only be done once:
+                                              when the Review load is the A load. So this routine is only called for A loads.
+
+                                              The NLET file entries that matter are either "S107" or "STOP"
+                                              The ACIS-Continuity.txt file adjustment will be SCS-107  for S107
+                                              or STOP for Full Stops.
+
+The graphical timeline representation of events:
+
+| Continuity-Continuity Load|    
+             |
+      Interrupt
+
+                      | Continuity load built, Reviewed and Approved prior to the interrupt |
+
+                                                                                                               |    Review Load |                                          
+"""
+# Create a parser instance
+myparser = argparse.ArgumentParser()
+
+# Adding  switches that are both REQUIRED and POSITIONAL
+
+myparser.add_argument("rev_load_ofls_dir", help="Full path to the Review load Directory.")
+
+myparser.add_argument("cont_load_dir", help="Full path to the Continuity load directory.")
+
+myparser.add_argument("nlet_file_path", help="Full path to the NLET file.")
+
+args = myparser.parse_args()
+
+# Create an array of event types to recognize
+event_types =  ["S107", "STOP", "VO_SCS-107"]
+
+# Capture the command line arguments into variables.
+rev_load_ofls_dir = args.rev_load_ofls_dir
+cont_load_dir = args.cont_load_dir
+nlet_file_path =  args.nlet_file_path
+      
+# Capture the Review and Continuity load week names
+rev_load_week = rev_load_ofls_dir[28:35]
+cont_load_week = cont_load_dir[28:35]
+
+# Create an instance of the Backstop History class
+BSC = BackstopHistory.Backstop_History_Class(
+            "ACIS-Continuity.txt",
+            nlet_file_path,
+            rev_load_ofls_dir,
+            0,
+        )
+
+# Create a path to the ACIS-Continuity.txt file
+cont_load_continuity_file_path = "/".join((cont_load_dir, "ACIS-Continuity.txt"))
+
+# Step 1 is to copy the ACIS-Continuity.txt file to ACIS-Continuity.txt.BAK
+try:
+    print('\n    Copying ACIS-Continuity.txt to ACIS-Continuity.txt.BAK')
+    shutil.copy(cont_load_dir+'/ACIS-Continuity.txt', cont_load_dir+'/ACIS-Continuity.txt.BAK')
+except OSError as err:
+    print(err)
+    print("Could not back up the ", cont_load_week, " ACIS-Continuity.txt file")
+else:
+    print('    Copy was successful')
+
+    # Step 2 - Read the contents of the ACIS-Continuity.txt file in the Continuity load
+    continuity_load_path, review_load_type, interrupt_time = BSC.get_continuity_file_info(cont_load_dir)
+        
+    # continuity_load_path contains the path to the Continuity load that was interrupted.
+    # Find out the start and stop time of that load.  Use those times for the event searach within NLET
+    cont_cont_cmds = BSC.Read_Review_Load(continuity_load_path)
+
+    # Now collect any events that occurred between the Continuity-Continuity load start and stop
+    # times
+    events = BSC.Find_Events_Between_Dates(BSC.review_file_tstart, BSC.review_file_tstop)
+
+    # Loop through any events found. If one of them is a STOP or S107 event then
+    # you must modify the second line of the Continuity Load's ACIS-Continuity.txt
+    # file with the Interrupt type and the interrupt time.
+    for each_event in events:
+        # Check to see if this event is in the array of event types to recognize
+        if  each_event.split()[1] in event_types:
+            
+            # This is one of the events so assemble the second line of the ACSI-Continuity.txt file
+            # Split the input line
+            split_line = each_event.split()
+
+            # Translate the S107 to SCS-107 if that is the event type
+            if split_line[1] == "S107":
+                out_event_type = "SCS-107"
+            else: # Otherwise use what's there.
+                out_event_type = split_line[1]
+                
+            # Assemble the output line with the date stamp and event type and cut time.
+            out_line = out_event_type+ " "+ split_line[0] 
+
+            # Write out the updated ACIS-Continuity.txt file
+            # Open the ACIS-Continuity.txt file for writing
+            f = open(cont_load_dir+"/ACIS-Continuity.txt", "w")
+
+            # Write out the fullpath to the Continuity load
+            f.write( continuity_load_path+"\n")
+
+            # Write out the interrupt type and cut time
+            f.write(out_line+"\n")
+
+            # Close the ACIS-Continuity.txt file
+            f.close()
+            
+                                                      
+        
+            
+            
+ 
+    

--- a/Adjust_ACIS-Continuity.py
+++ b/Adjust_ACIS-Continuity.py
@@ -53,9 +53,8 @@ rev_load_ofls_dir = args.rev_load_ofls_dir
 cont_load_dir = args.cont_load_dir
 nlet_file_path =  args.nlet_file_path
       
-# Capture the Review and Continuity load week names
-rev_load_week = rev_load_ofls_dir[28:35]
-cont_load_week = cont_load_dir[28:35]
+# Capture the  Continuity load week name
+cont_load_week = cont_load_dir.split("/")[-2]
 
 # Create an instance of the Backstop History class
 BSC = BackstopHistory.Backstop_History_Class(

--- a/Adjust_ACIS-Continuity.py
+++ b/Adjust_ACIS-Continuity.py
@@ -96,7 +96,7 @@ else:
         # Check to see if this event is in the array of event types to recognize
         if  each_event.split()[1] in event_types:
             
-            # This is one of the events so assemble the second line of the ACSI-Continuity.txt file
+            # This is one of the events so assemble the second line of the ACIS-Continuity.txt file
             # Split the input line
             split_line = each_event.split()
 

--- a/Release_Notes_V4.8.txt
+++ b/Release_Notes_V4.8.txt
@@ -1,0 +1,96 @@
+Change Description
+==================
+
+This update includes changes to the Load Review check programs to add the 1DPAMYT thermal model in the
+list of thermal models that lr runs, and automates a modification to the continuity load's ACIS-Continuity.txt file if
+required.
+
+A call to run the approved 1DPAMYT thermal model has been added to run_models.pl.
+
+Occasionally an executing load will be interrupted by an SCS-107-only or Full Stop
+after its follow on load was reviewed and approved. The follow on load can be, and has,
+been uplinked but run as Vehicle Only, until a new Return to Science load is built, approved
+and uplinked.
+
+An example of this is the MAY0624 - MAY1324 - MAY1424 load sequence:
+
+MAY0624 was running on the Spacecraft
+
+MAY1324 load was reviewed and approved as a Full Normal foillow on to MAY06
+
+Then the MAY0624 load was interrupted by an SCS-107
+
+MAY1324 was uplinked but run as Vehicle only.
+
+MAY1424 Return to Science load was built, reviewed, approved and uplinked.
+
+If lr has determined that a sequence similar to the above has occurred, the Vehicle Only load's ACIS-Continuity.txt file
+is modified with the interrupt type and the time of interrupt. This information is available in the NLET file.
+
+This adjustment need only be done once: when the Return to science Review load is the A load.
+So this functionality is only executed for A loads.
+
+
+
+
+Files Changed or added:
+=======================
+
+
+The updates can be seen here:
+
+https://github.com/acisops/lr/pull/xxxxxxxxxxxxxx
+
+
+Testing:
+======== 
+
+The 1DPAMYT model addition was tested during each test for the ACIS-Continuity.txt modification
+update.  The modified run_models.pl, which contains the added call to run the 1DPAMYT model, was used.
+The validation plots were checked for accurate predictions. The creation and population of the out_dpamyt
+subdirectory in the lr ofls directories was verified.
+
+The program Adjust_ACIS-Continuity.py was tested stand alone on copies of production load
+directories. 
+
+The test loads were created by copying production loads into new subdirectories with new names
+and lr was run against those loads.
+
+The production loads involved were:
+
+MAY0624A
+MAY1324A and MAY1324B
+MAY1424A and MAY1424B
+
+The MAY1324 A and B load were run with the updated lr (given a different load name) to insure that Normal loads
+are still reviewed normally with the Normal ACIS-Continuity.txt file created.  Then the MAY1424 A and B loads
+were run with the updated lr (also given a different name). The expected modification to the MAY1324B ACIS-Continuity.txt
+file was observed when the MAY1424A load was run through lr.  No change to the MAY1324B ACIS-Continuity.txt file was
+obsereved for the lr run of the MAY1424B load, as expected.
+
+There are no recent examples of the MAY0624 - MAY1424 event sequence where the interrupt was a Full Stop.
+Consequently in order to verify correct operation when a Full Stop did occur, a test version of the NonLoadTrackedEvents.txt
+file was created and a STOP was substituted for the SCS-107 entry for the interruption of the MAY0624 load. The MAY1424 A
+and B tests were re-run and the expected ACIS-Continuity.txt file update was observed.
+
+All tests passed.
+
+
+
+Interface impacts
+=================
+
+None
+
+
+Review
+====== 
+
+ACIS Ops
+
+
+Deployment Plan
+===============
+
+Will be deployed after FSDS approval.
+

--- a/Release_Notes_V4.8.txt
+++ b/Release_Notes_V4.8.txt
@@ -68,6 +68,9 @@ were run with the updated lr (also given a different name). The expected modific
 file was observed when the MAY1424A load was run through lr.  No change to the MAY1324B ACIS-Continuity.txt file was
 obsereved for the lr run of the MAY1424B load, as expected.
 
+Test load directories were also created where the Continuity load does not have an ACIS-Continuity.txt file to modify.
+This tests the error handling portion of Adjust_ACIS-Continuity.py.
+
 There are no recent examples of the MAY0624 - MAY1424 event sequence where the interrupt was a Full Stop.
 Consequently in order to verify correct operation when a Full Stop did occur, a test version of the NonLoadTrackedEvents.txt
 file was created and a STOP was substituted for the SCS-107 entry for the interruption of the MAY0624 load. The MAY1424 A

--- a/Release_Notes_V4.8.txt
+++ b/Release_Notes_V4.8.txt
@@ -39,7 +39,7 @@ Files Changed or added:
 
 The updates can be seen here:
 
-https://github.com/acisops/lr/pull/xxxxxxxxxxxxxx
+https://github.com/acisops/lr/pull/42
 
 
 Testing:

--- a/lr
+++ b/lr
@@ -734,7 +734,7 @@ if ( ($load_type eq "TOO") and ($upper_load_version eq "A") and \
   {
         print "\nOk this Review load: $cur_load ... is interrupting the $prev_load as a TOO interrupt\nbut I also notice that the continuity load, $prev_load, is to be treated as vehicle only.\n";
 	
-	print "\nWas the $prev_load reviewed as a ".color("bold")."NORMAL".color("reset")." load ".color("bold")."before".color("reset")." its continuity load was interrupted by an SCS-107 (either 107-only or Full Stop)\n and they uplinked $prev_load as VO just to keep the spacecraft maneuvering until a Return to Science load could be approved?[y/n]";
+	print "\nWas the $prev_load load reviewed as a ".color("bold")."NORMAL".color("reset")." load ".color("bold")."before".color("reset")." its continuity load was interrupted by an SCS-107 (either 107-only or Full Stop),\nsubsequently uplinked as a full load (i.e. Both Science and Vehicle portions), but only the Vehicle Commands were activated\njust to keep the spacecraft maneuvering until a Return to Science load could be approved?[y/n]";
 	$ans_cont_interrupted=<STDIN>;
 	chop($ans_cont_interrupted);
         print "\nResponse: $ans_cont_interrupted\n";

--- a/lr
+++ b/lr
@@ -8,6 +8,10 @@ use File::Copy;
 use Cwd;
 use Archive::Tar;
 use Plucknames;
+
+use Term::ANSIColor;
+use File::Copy;
+
 #Save time executing Load Reviews
 #Creates neccesary directories for current load.
 #SFTP's to lucky, user enters name and pwd and 
@@ -164,10 +168,16 @@ use Plucknames;
 #               to continue the migration from Perl to Python.
 #         - Added HRC/TXING time delta check
 #
+# Update: June 11, 2040
+#              V4.5
+#              - Determine if the VOC[B] continuity load was uplinked and run as VO; adjust
+#                Continuity ACIS-Continuity.txt file if necessary
+#
 ###########################################################
 # usage: lr [present load] [previous week]                #
 #         example:  lr AUG2701A AUG2001                   #
-###########################################################  
+###########################################################
+
 #
 # Set up autoflush
 $| = 1;
@@ -603,7 +613,7 @@ else # List is empty inform the user. Give the user the chance to specify one
 
 # Load version in ORLIST .or files are always uppercase
 # Create the upper case.
-$uc_load_version = uc $load_version;
+$upper_load_version = uc($load_version);
 
 # Formulate the name of the ORLIST lor file for this load and version
 $orlist_file_name = $load_name."_".$uc_load_version.".or";
@@ -702,14 +712,49 @@ system("python3 /data/acis/LoadReviews/script/Tarfile_Extract.py --nargs $file  
 #----------------------------------------
 if ($break == 1)
   {
-    # lr_break returns the load type and the interrupt time
-    $load_type,$interrupt_time =  lr_break();
+      # lr_break returns the load type and the interrupt time
+      $load_type,$interrupt_time =  lr_break();
     $hist=$edit_hist;
   }
 
+# Now that you know the load type (e.g. Normal, SCS-107, Full Stop, TOO) and
+# the value of the VO switch (if any) it's time to check for the circumstance where
+# the continuity load was reviewed as NORMAL but then after the approval, ITS
+# continuity load was interrupted by an SCS-107 (either a 107-only or Full Stop).
+# 
+# Check to see if this is a TOO type load, whether it's the A load, and if the VO flag was set as VOC or VOB
+# If so, then ask the user if the continuity load was uplinked and run as a Vehicle Only
+# to fill in after ITS continuity load was interrupted by an SCS-107 (either 107-only
+# or a Full Stop)
+#
+# NOTE: The adjustment will be made even if this is a Test load.
+#
+if ( ($load_type eq "TOO") and ($upper_load_version eq "A") and \
+     (($VO_choice eq "VOC") or ($VO_choice eq "VOB")))
+  {
+        print "\nOk this Review load: $cur_load ... is interrupting the $prev_load as a TOO interrupt\nbut I also notice that the continuity load, $prev_load, is to be treated as vehicle only.\n";
+	
+	print "\nWas the $prev_load reviewed as a ".color("bold")."NORMAL".color("reset")." load ".color("bold")."before".color("reset")." its continuity load was interrupted by an SCS-107 (either 107-only or Full Stop)\n and they uplinked $prev_load as VO just to keep the spacecraft maneuvering until a Return to Science load could be approved?[y/n]";
+	$ans_cont_interrupted=<STDIN>;
+	chop($ans_cont_interrupted);
+        print "\nResponse: $ans_cont_interrupted\n";
+
+	# See what the user's answer was
+	if ((uc $ans_cont_interrupted) eq "Y")
+	{
+	    # Call the Python program to modify the ACSI-Continuity.txt file within
+	    # the Continuity load directory
+	    system("python3 /data/acis/LoadReviews/script/Adjust_ACIS-Continuity.py $ofls_dir $prev_load_dir $nlet_file");
+	    print "\nAdjustment made to the $prev_load ACIS-Continuity.txt file\n";
+	  }
+
+    } # END IF ( ($load_type eq "TOO") &&  (($vo_choice eq "VOC") || ($vo_choice eq "VOB")))
+
+
+
 # ------------------  CONTINUITY TRACKING -----------------------------
 # You now know everything you need to know in order to write
-# out the ACIS-Continuity.txt file
+# out the ACIS-Continuity.txt file in the Review load directory
 
 # Open the ACIS-Continuity.txt file
 open(CONTFILE, ">$ofls_dir/ACIS-Continuity.txt");
@@ -728,7 +773,7 @@ print CONTFILE $prev_load_dir.$ofls_val, "\n";
 # should be read for both the Review and the Continuity load.  But this piece of code
 # handles what gets written to the ACIS-Continuity.txt file. So in both cases (VOC and VOB)
 # You want ACIS-Continuity.txt to indicate vehicle-only for the Continuity load.
-# Reading the VR*.backstop file for the review load is handled by the call to run-models.pl.
+# Reading the VR*.backstop file for the review load is handled by the call to run_models.pl.
 if  ( ($VO_choice eq "VOC") || ($VO_choice eq "VOB") )
   {
     # User selected VOC for the VO switch. Tell the model to read
@@ -1240,7 +1285,7 @@ sub lr_break()
     $load_type = "TOO";
 
     # Initialize these user inputs to a meaningless number
-    # User inpute are either 1 (NO) or 2 (YES)
+    # User inputs are either 1 (NO) or 2 (YES)
     $ans107 = 0;
     $approved_once_answer = 0;
     $interrupt_same_answer = 0;
@@ -1352,13 +1397,13 @@ if (${load_version} eq "a" || $q eq "2")
     else # Otherwise it was a TOO load
          # This variable set may not be strictly necessary since load_type is initialized at the
          # top of the subroutine. But I hate fall through default results like that
-      {$load_type = "TOO";}
-        
+    {$load_type = "TOO";}
+         
      # Inform the user what type of load was determined from this subroutine.
-     print "\n\nI have determined that the Review Load is of type: $load_type\n\n";
+    print "\n\nI have determined that the Review Load is of type: $load_type\n\n";
 
     # Capture the interrupt time
-    print "\tPlease enter the interrupt time in format YYYY:DOY:HH:MM:SS.SS\n";
+    print "\tPlease enter the TOO interrupt time in format YYYY:DOY:HH:MM:SS.SS\n";
     $interrupt_time = <STDIN>;
     chop($interrupt_time);
 

--- a/lr
+++ b/lr
@@ -168,7 +168,7 @@ use File::Copy;
 #               to continue the migration from Perl to Python.
 #         - Added HRC/TXING time delta check
 #
-# Update: June 11, 2040
+# Update: June 11, 2024
 #              V4.5
 #              - Determine if the VOC[B] continuity load was uplinked and run as VO; adjust
 #                Continuity ACIS-Continuity.txt file if necessary

--- a/run_models.pl
+++ b/run_models.pl
@@ -36,7 +36,12 @@
 #         - Remove the no longer needed call to make_dhheater_history.csh
 #            - Broken under RH8/DS10.11
 #         - Print a line indicating what thermal model is about to be run
-	     
+#
+# Update: June 3, 2024
+#              Gregg Germain
+#              V1.17
+#              - Add the necessary code to run the new 1DPAMYT thermal model
+#
 #--------------------------------------------------------------------
 use POSIX qw(uname);
 use Cwd;
@@ -96,6 +101,10 @@ if ($appx) {  # On backup machine?
 #------------------------------
 $outdir=<${webroot}/PSMC_thermPredic/$load/ofls${ver}/>;
 $dpadir=<${webroot}/DPA_thermPredic/$load/ofls${ver}/>;
+
+# New web directory for the 1DPAMYT thermal model
+$dpamytdir=<${webroot}/DPAMYT_thermPredic/$load/ofls${ver}/>;
+
 $deadir=<${webroot}/DEA_thermPredic/$load/ofls${ver}/>;
 $fpdir=<${webroot}/FP_thermPredic/$load/ofls${ver}/>;
 $fep1acteldir=<${webroot}/FEP1_ACTEL_thermPredic/$load/ofls${ver}/>;
@@ -162,6 +171,9 @@ $psmc_ska_str = "${ska}/bin/psmc_check --oflsdir=${lr_dir} --out ${lr_dir}/out_p
 # NLET-DPA
 $dpa_ska_str = "${ska}/bin/dpa_check --oflsdir=${lr_dir} --out ${lr_dir}/out_dpa --nlet_file ${nlet_file}  --verbose=0 $break_str";
 
+# NLET-DPAMYT
+$dpamyt_ska_str = "${ska}/bin/dpamyt_check --oflsdir=${lr_dir} --out ${lr_dir}/out_dpamyt --nlet_file ${nlet_file}  --verbose=0 $break_str";
+
 # NLET-DEA
 $dea_ska_str = "${ska}/bin/dea_check --oflsdir=${lr_dir} --out ${lr_dir}/out_dea --nlet_file ${nlet_file}  --verbose=0 $break_str";
 
@@ -176,12 +188,13 @@ $beppcb_ska_str = "${ska}/bin/bep_pcb_check --oflsdir=${lr_dir} --out ${lr_dir}/
 # items to run
 #------------------------------
 @executables=( $psmc_ska_str,
-	      $dpa_ska_str,
-	      $dea_ska_str,
-              $fp_ska_str,
-	      $fep1mong_ska_str,
-	      $fep1actel_ska_str,
-	      $beppcb_ska_str);
+                            $dpa_ska_str,
+	                    $dpamyt_ska_str,
+                            $dea_ska_str,
+                            $fp_ska_str,
+	                    $fep1mong_ska_str,
+	                    $fep1actel_ska_str,
+	                    $beppcb_ska_str);
 
 # IF we can't execute this on this machine, then run it on acis
 if ($OS !~ /Linux/i ||
@@ -230,6 +243,12 @@ unless ($path){
     unless (-d $dpadir){
 	mkpath($dpadir,0777);
     }
+
+    unless (-d $dpamytdir)
+      {
+	mkpath($dpamytdir,0777);
+      }
+    
     unless (-d $deadir){
         mkpath($deadir,0777);
     }
@@ -247,6 +266,9 @@ unless ($path){
     }
     system("cp -p ${lr_dir}/out_psmc/*.* ${outdir}");   
     system("cp -p ${lr_dir}/out_dpa/*.* ${dpadir}");
+	
+    system("cp -p ${lr_dir}/out_dpamyt/*.* ${dpamytdir}");
+	
     system("cp -p ${lr_dir}/out_dea/*.* ${deadir}");
     system("cp -p ${lr_dir}/out_fptemp/*.* ${fpdir}");
     system("cp -p ${lr_dir}/out_fep1_mong/*.* ${fep1mongdir}");


### PR DESCRIPTION
This update includes changes to the Load Review check programs to add the 1DPAMYT thermal model in the
list of thermal models that lr runs, and automates a modification to the continuity load's ACIS-Continuity.txt file if
required.

A call to run the approved 1DPAMYT thermal model has been added to run_models.pl.

Occasionally an executing load will be interrupted by an SCS-107-only or Full Stop
after its follow on load was reviewed and approved. The follow on load can be, and has,
been uplinked but run as Vehicle Only, until a new Return to Science load is built, approved
and uplinked.

An example of this is the MAY0624 - MAY1324 - MAY1424 load sequence:

MAY0624 was running on the Spacecraft

MAY1324 load was reviewed and approved as a Full Normal foillow on to MAY06

Then the MAY0624 load was interrupted by an SCS-107

MAY1324 was uplinked but run as Vehicle only.

MAY1424 Return to Science load was built, reviewed, approved and uplinked.

If lr has determined that a sequence similar to the above has occurred, the Vehicle Only load's ACIS-Continuity.txt file
is modified with the interrupt type and the time of interrupt. This information is available in the NLET file.

This adjustment need only be done once: when the Return to science Review load is the A load.
So this functionality is only executed for A loads.
