### PR TITLE
Changes to accommodate Python 3.12.8 of the SKA 2025.1 update

### DIFF
--- a/Release_Notes_V4.9.1.txt
+++ b/Release_Notes_V4.9.1.txt
@@ -1,0 +1,53 @@
+Change Description
+==================
+
+This is an update to support routines that accommodates the ska 2025.1 update to Python 3.12.8.
+
+
+Files Changed or added:
+=======================
+
+
+The updates can be seen here:
+
+https://github.com/acisops/lr/pull/44
+
+
+Testing:
+======== 
+
+Each of the programs were tested by running full regression tests.  These were
+carried out by arranging for LR to call the updated programs during test runs of Normal,
+TOO, SCS-107-only and Full Stop loads. ACIS-LoadReview.txt output files and
+thermal model plots were compared and all differences were understood. No unit tests
+were carried out.
+
+
+The production loads involved were:
+
+FEB0325A
+JAN0325A
+JAN1425A
+FEB0724A
+
+All tests passed.
+
+
+
+Interface impacts
+=================
+
+None
+
+
+Review
+====== 
+
+ACIS Ops
+
+
+Deployment Plan
+===============
+
+Will be deployed after FSDS approval.
+

--- a/Release_Notes_V4.9.1.txt
+++ b/Release_Notes_V4.9.1.txt
@@ -1,7 +1,7 @@
 Change Description
 ==================
 
-This is an update to support routines that accommodates the ska 2025.1 update to Python 3.12.8.
+This is an update to support routines to accommodate the ska 2025.1 update to Python 3.12.8.
 
 
 Files Changed or added:

--- a/UTILITIES/Insert_Comment_In_ALR.py
+++ b/UTILITIES/Insert_Comment_In_ALR.py
@@ -52,7 +52,7 @@ def Insert_Comment_In_ALR( comment_list, ALR_path, extension = "COMMENTS"):
     # the start
     #
     # Define regular expressions to be used in backstop file line searches
-    time_stamp = re.compile('\d\d\d\d:\d\d\d:\d\d:\d\d:\d\d.\d\d\d')
+    time_stamp = re.compile('\\d\\d\\d\\d:\\d\\d\\d:\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d')
     
     # Get the indices of all those lines which begin with a DOY time stamp
     # This is the position of the time stamped line in the ALR file.

--- a/WINDOW_CHECK/Window_Check.py
+++ b/WINDOW_CHECK/Window_Check.py
@@ -62,7 +62,7 @@ import SI_Mode_Class
 # Inits
 error_list = []
 # regex for time stamps in ACIS-LoadReview.txt files
-DOY_full_3f = re.compile('\d\d\d\d:\d\d\d:\d\d:\d\d:\d\d.\d\d\d$')
+DOY_full_3f = re.compile('\\d\\d\\d\\d:\\d\\d\\d:\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d$')
 
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Small updates to support routines that accommodate the update to Python 3.12.8.