### PR TITLE
LR updates: run_models.py, OBSID timing error fix

### DIFF
--- a/Adjust_ACIS-Continuity.py
+++ b/Adjust_ACIS-Continuity.py
@@ -33,7 +33,13 @@ The graphical timeline representation of events:
 
                       | Continuity load built, Reviewed and Approved prior to the interrupt |
 
-                                                                                                               |    Review Load |                                          
+                          
+                                                                                                             |    Review Load |                   
+
+Update: July 23, 2025
+              Gregg Germain
+              Comment updates
+                       
 """
 # Create a parser instance
 myparser = argparse.ArgumentParser()

--- a/Adjust_ACIS-Continuity.py
+++ b/Adjust_ACIS-Continuity.py
@@ -22,6 +22,9 @@ Adjust_ACIS-Continuity.py - LR has determined that a continuity load was reviewe
                                               The ACIS-Continuity.txt file adjustment will be SCS-107  for S107
                                               or STOP for Full Stops.
 
+                                              The NLET file is not modified. It is only used only to determine the type of load
+                                              interruption.
+ 
 The graphical timeline representation of events:
 
 | Continuity-Continuity Load|    

--- a/CHECK_POWER_COMMANDS/Check_Power_Cmds.py
+++ b/CHECK_POWER_COMMANDS/Check_Power_Cmds.py
@@ -25,7 +25,7 @@
 #         - Removed deprecated Chandra.Time
 #         - Eliminated commented-out line
 #
-# Update: February 15, 2022
+# Update: July 23, 2025
 #          Gregg Germain
 #          - Allow for the case of a Vehicle-Only Review load where there are no ACISPKT commands
 #

--- a/CHECK_POWER_COMMANDS/Check_Power_Cmds.py
+++ b/CHECK_POWER_COMMANDS/Check_Power_Cmds.py
@@ -1,7 +1,7 @@
 ################################################################################
 #
 #  Check_Power_Cmds - Check the power command spacing in the load to see if the
-#                     rules ahve been adhered to. Any errors are inserted into a
+#                     rules have been adhered to. Any errors are inserted into a
 #                     new ACIS-LoadReviews.dat file.
 #
 #                     For the time being, this new file is kept separate from
@@ -31,7 +31,6 @@
 #
 ################################################################################
 import argparse
-
 import glob
 
 # bring in the system state class
@@ -162,7 +161,7 @@ python3 /data/acis/LoadReviews/script/CHECK_POWER_COMMANDS/Check_Power_Cmds.py
     If it did not, then stop.
 """
 # Using ARGPARSE
-cl_parser = argparse.ArgumentParser(description='WeeklyPDAMS plots')
+cl_parser = argparse.ArgumentParser(description='Check Power Commands program')
 
 # Add the TEST argument as NON-POSITIONAL.  
 cl_parser.add_argument("-t", '--test', help='In test mode, plots are not moved to htdocs', action="store_true")
@@ -207,7 +206,7 @@ present_cmd = system_packets[array_row_number]
 
 
 # If this is a Vehicle-Only Review load then there will be no ACISPKT commands within the load.
-# So skip the while loop which is intended ot take you to the first one.  
+# So skip the while loop which is intended to take you to the first one.  
 # This means that array_row_number will equal 0
 
 if 'ACISPKT' in system_packets['cmd_type']:
@@ -298,7 +297,7 @@ for eachpacket in system_packets[array_row_number:]:
  
     # Append any violations you found to the master violations list
     if violations_list:
-        all_violations+= violations_list[0]
+        all_violations += violations_list[0]
 
 
 if len(all_violations) == 0:

--- a/Release_Notes_V5.0.txt
+++ b/Release_Notes_V5.0.txt
@@ -1,0 +1,79 @@
+Change Description
+==================
+
+lr is the ACIS Operations  review load processing program. Updates were made to lr and to several of the
+other programs lr executes.
+
+lr, itself, was modified to fix an IF statement that incorrectly analyzed if a load was of the type TOO and the
+continuity load is Vehicle Only. lr was also  modified to call the new run_models.py which replaces run_models.pl
+
+The following updated programs are excuted by lr:
+
+run_models.py was written to continue the conversion of load review programs from Perl to Python. run_models.py included
+a new switch allowing for easier unit testing on existing Production loads.  No interface changes.
+
+acisbackstop.pl was modified to eliminate false errors generated when calculating the time delta
+between an observation's Stop Science command and the next command to change the Obsid.
+
+Check_Power_Cmds.py was modified to be more efficient by avoiding the ACISPKT processing loop when processing a
+Vehicle Only load.
+
+Other updates includes fixing typos and making comments more clear.
+
+
+
+
+
+
+Files Changed or added:
+=======================
+
+
+The updates can be seen here:
+
+https://github.com/acisops/lr/pull/
+
+
+Testing:
+======== 
+
+Unit tests were carried out by running  test scenarios on all the updated  programs except lr.
+
+Then full regression tests were carried out by arranging for the updated lr to call the new
+ programs on Normal, TOO, SCS-107-only and Full Stop loads and loads with and without Vehicle Only Continuity loads. ACIS-LoadReview.txt output files and
+thermal model plots were compared and all differences were understood. 
+
+
+The production loads involved were:
+
+JUL1425A
+APR2825A
+MAY0525A
+MAR2625A
+MAR2725A
+JAN1525A
+
+JAN2624A
+OCT1324A & B
+
+All tests passed.
+
+
+
+Interface impacts
+=================
+
+None
+
+
+Review
+====== 
+
+ACIS Ops
+
+
+Deployment Plan
+===============
+
+Will be deployed after FSDS approval.
+

--- a/Release_Notes_V5.0.txt
+++ b/Release_Notes_V5.0.txt
@@ -31,7 +31,7 @@ Files Changed or added:
 
 The updates can be seen here:
 
-https://github.com/acisops/lr/pull/
+https://github.com/acisops/lr/pull/45
 
 
 Testing:

--- a/acis-backstop.pl
+++ b/acis-backstop.pl
@@ -80,7 +80,7 @@
 #               - Solve the ACIS-HRC-ACIS SI mode issue when the two ACIS SI
 #                 modes are the same.
 #
-# Update: November 15, 2024
+# Update: July 23, 2025
 #               V3.7
 #               - Eliminate the false error when acis-backstop uses the incorrect AA00 to
 #                 calculate the time between the Stop Science and Obsid Change

--- a/lr
+++ b/lr
@@ -173,7 +173,7 @@ use File::Copy;
 #              - Determine if the VOC[B] continuity load was uplinked and run as VO; adjust
 #                Continuity ACIS-Continuity.txt file if necessary
 #
-# Update January 16, 2025
+# Update July 23, 2025
 #              V4.6
 #              - Eliminated unnecessary question  regarding the Continuity load
 #              - Fixed the AA00 false error ( Fixed in acis-backstop.pl)

--- a/lr
+++ b/lr
@@ -173,6 +173,13 @@ use File::Copy;
 #              - Determine if the VOC[B] continuity load was uplinked and run as VO; adjust
 #                Continuity ACIS-Continuity.txt file if necessary
 #
+# Update January 16, 2025
+#              V4.6
+#              - Eliminated unnecessary question  regarding the Continuity load
+#              - Fixed the AA00 false error ( Fixed in acis-backstop.pl)
+#              - Runs run_models.py
+#              - Makes the request for the interrupt time general
+#
 ###########################################################
 # usage: lr [present load] [previous week]                #
 #         example:  lr AUG2701A AUG2001                   #
@@ -227,7 +234,7 @@ if ($VO_choice  ne "")
        die("FATAL ERROR - $VO_choice is an invalid value for the VO switch.\nValid values are: VOC, VOR, VOB\n");
       }
     else
-      { print "\n The VO value is: $VO_choice";}
+      { print "\n The supplied VO value is: $VO_choice";}
 
   }
 
@@ -721,7 +728,9 @@ if ($break == 1)
 # the value of the VO switch (if any) it's time to check for the circumstance where
 # the continuity load was reviewed as NORMAL but then after the approval, ITS
 # continuity load was interrupted by an SCS-107 (either a 107-only or Full Stop).
-# 
+#
+# You only want to do this once...so the test includes a test to see if this is the A load.
+#
 # Check to see if this is a TOO type load, whether it's the A load, and if the VO flag was set as VOC or VOB
 # If so, then ask the user if the continuity load was uplinked and run as a Vehicle Only
 # to fill in after ITS continuity load was interrupted by an SCS-107 (either 107-only
@@ -729,12 +738,11 @@ if ($break == 1)
 #
 # NOTE: The adjustment will be made even if this is a Test load.
 #
-if ( ($load_type eq "TOO") and ($upper_load_version eq "A") and \
-     (($VO_choice eq "VOC") or ($VO_choice eq "VOB")))
+if ( ($load_type eq "TOO") and ($upper_load_version eq "A") and (($VO_choice eq "VOC") or ($VO_choice eq "VOB")))
   {
         print "\nOk this Review load: $cur_load ... is interrupting the $prev_load as a TOO interrupt\nbut I also notice that the continuity load, $prev_load, is to be treated as vehicle only.\n";
 	
-	print "\nWas the $prev_load load reviewed as a ".color("bold")."NORMAL".color("reset")." load ".color("bold")."before".color("reset")." its continuity load was interrupted by an SCS-107 (either 107-only or Full Stop),\nsubsequently uplinked as a full load (i.e. Both Science and Vehicle portions), but only the Vehicle Commands were activated\njust to keep the spacecraft maneuvering until a Return to Science load could be approved?[y/n]";
+	print "\nWas the $prev_load load reviewed as a NORMAL load BEFORE its continuity load was interrupted by an SCS-107 (either 107-only or Full Stop),\nsubsequently uplinked as a full load (i.e. Both Science and Vehicle portions), but only the Vehicle Commands were activated\njust to keep the spacecraft maneuvering until a Return to Science load could be approved?[y/n]";
 	$ans_cont_interrupted=<STDIN>;
 	chop($ans_cont_interrupted);
         print "\nResponse: $ans_cont_interrupted\n";
@@ -1014,21 +1022,21 @@ else
 #---------------------------------------------------------------
 #
 # Run Check_Power_Cmds.py
-print "\nEXECUTING THE CHECK POWER COMMAND PROGRAM";
+print "\nEXECUTING THE CHECK POWER COMMAND PROGRAM\n";
 # PRODUCTION
 system("python3 /data/acis/LoadReviews/script/CHECK_POWER_COMMANDS/Check_Power_Cmds.py");
 
 # Now execute the Window Check program
-print "\nEXECUTING THE WINDOW CHECK PROGRAM.";
+print "\nEXECUTING THE WINDOW CHECK PROGRAM.\n";
 system('python3 /data/acis/LoadReviews/script/WINDOW_CHECK/Window_Check.py');
 
 # Next execute the SCS-155 Deadman Check
-print "\nEXECUTING THE SCS-155 DEADMAN CHECK PROGRAM";
+print "\nEXECUTING THE SCS-155 DEADMAN CHECK PROGRAM\n";
 
 system("python3 /data/acis/LoadReviews/script/DEADMAN_SCS_155/Deadman_Check.py ${ofls_dir} ${nlet_file}");
 
 # Next execute the HETG Check
-print "\nEXECUTING HETG CHECK PROGRAM";
+print "\nEXECUTING HETG CHECK PROGRAM\n";
 
 system("python3 /data/acis/LoadReviews/script/HETG_CHECK/HETG_Check.py ${ofls_dir} ${nlet_file}");
 
@@ -1041,7 +1049,7 @@ else
   {system("python3 /data/acis/LoadReviews/script/IDLE_DWELL/Find_Idle_Dwells.py  ${ofls_dir}  --vo ${VO_choice}   ");}
 
 # Execute the HRC/TXINGING Timing check
-print "\nEXECUTING THE HRC TXING TIMING CHECK PROGRAM.";
+print "\nEXECUTING THE HRC TXING TIMING CHECK PROGRAM.\n";
 system("python3 /data/acis/LoadReviews/script/HRC_TXING_CHECK/HRC_Txing_Check.py ${ofls_dir} ");
 
 # Read in the ORLIST file
@@ -1067,7 +1075,7 @@ system("$script_dir/backstop_comp.sh");
 # Run psmc_check and dpa_check, dea_check and fp_check...
 # will secure shell to acis.cfa.harvard.edu if not on a linux machine
 #--------------------------------------------------------------------
-print "\nRunning the thermal code...\n";
+print "\nRunning the Thermal Model Programs...\n";
 if ($appx) {
     print "\nThermal models skipped when not on HEAD LAN\n";
 } else {
@@ -1088,13 +1096,12 @@ if ($appx) {
         # the "for score" ofls directory.
         if($test_dir)
             {
-              # Production
-	      system("$script_dir/run_models.pl $cur_load -h $hostname -p $ofls_dir $break_str -nlet_file $nlet_file");
-
+		# PRODUCTION - Test mode - do not copy output files to the production web directory
+		system("python3 $script_dir/run_models.py $cur_load  --oflsdir  $ofls_dir $break_str --nlet_file $nlet_file -t");
             }
         else
-            {
-	      system("$script_dir/run_models.pl $cur_load -h $hostname $break_str -nlet_file $nlet_file");
+	{     # PRODUCTION - For score - copy output files to the production web directory
+	       system("python3 $script_dir/run_models.py $cur_load  $break_str --nlet_file $nlet_file");
             }
 
       } #ENDIF NOT NOMODELS
@@ -1106,7 +1113,7 @@ if ($appx) {
 	system("$script_dir/mk_thermal_html.pl $cur_load");
     }
 }
-print "Done with thermal codes...\n\n";
+print "\nDone with the thermal model programs...\n\n";
 
 #--------------------------------------------------
 #close down
@@ -1403,7 +1410,7 @@ if (${load_version} eq "a" || $q eq "2")
     print "\n\nI have determined that the Review Load is of type: $load_type\n\n";
 
     # Capture the interrupt time
-    print "\tPlease enter the TOO interrupt time in format YYYY:DOY:HH:MM:SS.SS\n";
+    print "\tPlease enter the interrupt time in format YYYY:DOY:HH:MM:SS.SS\n";
     $interrupt_time = <STDIN>;
     chop($interrupt_time);
 

--- a/run_models.py
+++ b/run_models.py
@@ -53,7 +53,7 @@ There are a number of changes between this version and the perl version.
    /data/acis/LoadReviews/script/run_models.pl load_name -h $hostname  ofls_dir break_string -nlet_file $nlet_file 
 
  Production Run:
- /data/acis/LoadReviews/script /run_models.py load_name -h $hostname $break_str -nlet_file $nlet_file
+ /data/acis/LoadReviews/script/run_models.py load_name -h $hostname $break_str -nlet_file $nlet_file
 
  Inputs: load_name - Required. Name of the Review load including letter (e.g. AUG0924A) comes from LR
 

--- a/run_models.py
+++ b/run_models.py
@@ -72,7 +72,7 @@ There are a number of changes between this version and the perl version.
                                   - and if you don't specify the --out switch, run_models will WRITE into that PRODUCTION ofls directory.
 
                              NOTE: If you are running run_models.py from lr, and use the -T switch on lr, then --out need not be specified 
-                                        and the out_* directories will appear under th eTEST directory.
+                                        and the out_* directories will appear under the TEST directory.
 
              out - Optional full, alternate path for the out_* directories. This allows you to run the models
                      on a production load but not write the output files into the production ofls directory.
@@ -98,7 +98,7 @@ Path to OFLS directory                    ---                                   
 Path to OFLS directory      Path to output directory              Path to OFLS directory                         Path to output directory
 
    The formulated path to the OFLS directory is:  /data/acis/LoadReviews/<year>/<load>/ofls<version letter>
-   It is based upon the load week and version letter which are  required input.
+   It is based upon the load week and version letter which are required input.
 
  Example command line for the 1DPAMZT model:
 

--- a/run_models.py
+++ b/run_models.py
@@ -38,7 +38,7 @@ There are a number of changes between this version and the perl version.
     compatibility,
 
     This means that if you want to put the output files anywhere other than the ofls directory you MUST
-    specify where they should go, withthe path switch.  The Perl version used the $path variable to
+    specify where they should go, with the path switch.  The Perl version used the $path variable to
     determine whether or not to copy the plot files to the web for display.  Since we have disassociated path from oflsdir
     we need another way to prevent copies to the web page.  For that, we use the --web switch.
 
@@ -47,13 +47,12 @@ There are a number of changes between this version and the perl version.
  is an issue. 
 
 
-  Usage:
- Specifying a Test Directory:
- 
-   /data/acis/LoadReviews/script/run_models.py load_name -h $hostname  ofls_dir break_string -nlet_file $nlet_file 
+ Usage:
 
- Production Run:
- /data/acis/LoadReviews/script/run_models.py load_name -h $hostname $break_str -nlet_file $nlet_file
+run_models.py [-h] [--oflsdir OFLSDIR] [--out OUT] [-b]
+                     [--nlet_file NLET_FILE] [--verbose VERBOSE] [-t]
+                     load_name
+
 
  Inputs: load_name - Required. Name of the Review load including letter (e.g. AUG0924A) comes from LR
 
@@ -83,6 +82,8 @@ There are a number of changes between this version and the perl version.
              nlet_file - Full path to the NLET file to be used. (e.g. /data/acis/LoadReviews/NonLoadTrackedEvents.txt)
                                 - The default is the production version
 
+             -verbose - Specifies the level of verbosity for the acis_thermal_model run
+
              -t - If true, write the out_<model> subdirectories to the TEST web pages. The default is False to eliminate
                    the need to specify this switch and maintain backwards compatibility. So if this switch is False, the resultant
                    output files will be written to the PRODUCTION web pages.
@@ -100,9 +101,6 @@ Path to OFLS directory      Path to output directory              Path to OFLS d
    The formulated path to the OFLS directory is:  /data/acis/LoadReviews/<year>/<load>/ofls<version letter>
    It is based upon the load week and version letter which are required input.
 
- Example command line for the 1DPAMZT model:
-
-    /proj/sot/ska3/flight/bin/dpa_check APR2825 --oflsdir  /data/acis/LoadReviews/2025/APR2825/ofls -nlet_file nlet_file "b"
 
  Initial: July 23, 2025
            Gregg Germain
@@ -111,15 +109,15 @@ Path to OFLS directory      Path to output directory              Path to OFLS d
 
 # Set up the parser
 rmparser = argparse.ArgumentParser()
-rmparser.add_argument("load_name", help="Name of the Review load including letter (e.g. AUG0924A)")
-rmparser.add_argument("--oflsdir", help="Full path to the OFLS directory of the review load")
-rmparser.add_argument("--out", help="Full path output  directory for the out_* files (e.g. /data/acis/LoadReviews/2025/APR2825/ofls)")
+rmparser.add_argument("load_name", type=str, help="Name of the Review load including letter (e.g. AUG0924A)")
+rmparser.add_argument("--oflsdir", type=str, help="Full path to the OFLS directory of the review load")
+rmparser.add_argument("--out", type=str,  help="Full path output  directory for the out_* files (e.g. /data/acis/LoadReviews/2025/APR2825/ofls)")
 rmparser.add_argument("-b", help="If in the command line, specifies if the load is an interrupt load",  action="store_true")
 
-rmparser.add_argument("--nlet_file", help="Full Path to the Non Load Event Tracking file to be used", default="/data/acis/LoadReviews/NonLoadTrackedEvents.txt" )
-rmparser.add_argument("--verbose", help="Indicates verbosity of debug comments", default = 0)
+rmparser.add_argument("--nlet_file", type=str, help="Full Path to the Non Load Event Tracking file to be used", default="/data/acis/LoadReviews/NonLoadTrackedEvents.txt" )
+rmparser.add_argument("--verbose",  type=str, help="Indicates verbosity of debug comments", default = 0)
 
-rmparser.add_argument("-t", help="Flag to allow/prevents writing the out_<model> directories to the web page", action="store_true")
+rmparser.add_argument("-t", help="Flag to allow/prevent writing the out_<model> directories to the web page", action="store_true")
 
 # Get the arguments
 args = rmparser.parse_args()
@@ -143,14 +141,14 @@ if args.oflsdir:
     oflsdir = args.oflsdir
 else:
     # Formulate the PRODUCTION directory
-    oflsdir = "/".join(("/data/acis/LoadReviews/" + year, load, "ofls"+ver.lower()))
+    oflsdir = os.path.join("/data/acis/LoadReviews/" + year, load, "ofls"+ver.lower())
 
 # OUT - If a --out switch value was supplied, capture it. Otherwise write the output
 # files into the OFLS directory (as you would for production or when you use the -T switch
 # in LR)
 if args.out:
     # Use the supplied output directory and add to it.
-    out_dir = "/".join((args.out,  "ofls"+ver.lower()))
+    out_dir = os.path.join(args.out,  "ofls"+ver.lower())
 else: #...otherwise the output directory is the same as the ofls directory
     out_dir =  oflsdir
 
@@ -187,18 +185,18 @@ ska_bin_base = '/proj/sot/ska3/flight/bin/'
 # Argument list for us in formulating the run_models command. Specifies
 # the model name, part of the output directory where resultant files are located,
 # and part of the path where the web copies are located.
-# There r twopossibilities: if you are running for production the web page
+# There are two possibilities: if you are running for production the web page
 # subdirectory is the Production subdir. Otherwise it's a test directory
 
 # TEST
 if test_flag == True:
     exec_args = [ ["dpa_check", "out_dpa", "TEST_DPA_thermPredic"],
-                           ["psmc_check",  "out_psmc", "TEST_PSMC_thermPredic"],
-                           ["dpamyt_check", "out_dpamyt", "TEST_DPAMYT_thermPredic"],
-                           ["dea_check", "out_dea", "TEST_DEA_thermPredic"],
+                           ["psmc_check", "out_psmc", "TEST_PSMC_thermPredic"],
+                           ["dpamyt_check",  "out_dpamyt", "TEST_DPAMYT_thermPredic"],
+                           ["dea_check",  "out_dea", "TEST_DEA_thermPredic"],
                            ["acisfp_check", "out_fptemp", "TEST_FP_thermPredic"],
                            ["fep1_mong_check", "out_fep1_mong", "TEST_FEP1_MONG_thermPredic"],
-                           ["fep1_actel_check",  "out_fep1_actel",  "TEST_FEP1_ACTEL_thermPredic"],
+                           ["fep1_actel_check", "out_fep1_actel", "TEST_FEP1_ACTEL_thermPredic"],
                            ["bep_pcb_check", "out_bep_pcb", "TEST_BEP_PCB_thermPredic"]]
 else:
     exec_args = [ ["dpa_check", "out_dpa", "DPA_thermPredic"],
@@ -221,7 +219,7 @@ for each_model in exec_args:
     print("\nExecuting model: ", each_model[0])
     sys.stdout.flush()
     
-    out_path = "/".join((out_dir, each_model[1]))
+    out_path = os.path.join(out_dir, each_model[1])
     # Now create the command line for executing this model 
     model_cmd_line = " ".join((ska_bin_base + each_model[0], "--oflsdir", oflsdir, "--out", out_path, "--nlet_file", nlet_file, "--verbose", verbose_val, break_str ))
 
@@ -232,7 +230,7 @@ for each_model in exec_args:
     # into the appropriate web directory: either the TEST or PRODUCTION directory
 
     # Formulate the web destination
-    web_dir_dest = "/".join((webroot, each_model[2], load, "ofls" + ver.lower(), each_model[1] ))
+    web_dir_dest = os.path.join(webroot, each_model[2], load, "ofls" + ver.lower() )
    
     # Does the directory exist?
     dir_exist = os.path.isdir(web_dir_dest)
@@ -243,5 +241,5 @@ for each_model in exec_args:
 
     # Copy each file in the directory
     for item in os.listdir(out_path):
-        shutil.copy2("/".join((out_path, item)), web_dir_dest)
+        shutil.copy2(os.path.join(out_path, item), web_dir_dest)
         

--- a/run_models.py
+++ b/run_models.py
@@ -50,7 +50,7 @@ There are a number of changes between this version and the perl version.
   Usage:
  Specifying a Test Directory:
  
-   /data/acis/LoadReviews/script/run_models.pl load_name -h $hostname  ofls_dir break_string -nlet_file $nlet_file 
+   /data/acis/LoadReviews/script/run_models.py load_name -h $hostname  ofls_dir break_string -nlet_file $nlet_file 
 
  Production Run:
  /data/acis/LoadReviews/script/run_models.py load_name -h $hostname $break_str -nlet_file $nlet_file

--- a/run_models.py
+++ b/run_models.py
@@ -104,7 +104,7 @@ Path to OFLS directory      Path to output directory              Path to OFLS d
 
     /proj/sot/ska3/flight/bin/dpa_check APR2825 --oflsdir  /data/acis/LoadReviews/2025/APR2825/ofls -nlet_file nlet_file "b"
 
- Initial: August 23, 2024
+ Initial: July 23, 2025
            Gregg Germain
 
 """

--- a/run_models.py
+++ b/run_models.py
@@ -208,6 +208,9 @@ else:
                            ["fep1_actel_check",  "out_fep1_actel",  "FEP1_ACTEL_thermPredic"],
                            ["bep_pcb_check", "out_bep_pcb", "BEP_PCB_thermPredic"] ]
 
+models = ["dpa", "psmc", "dpamyt", "dea", "acisfp", "fep1_mong", "fep1_actel", "bep_pcb"]
+
+prefix = "TEST_" if test_flag else ""
 
 # Specify the base web directory
 webroot = "/proj/web-cxc/htdocs/acis"
@@ -215,13 +218,18 @@ webroot = "/proj/web-cxc/htdocs/acis"
 # Now run each model and create the web directory for the output files, and copy
 # the files into that directory
 #
-for each_model in exec_args:
-    print("\nExecuting model: ", each_model[0])
+for each_model in models:
+    print("\nExecuting model: ", each_model)
     sys.stdout.flush()
+
+    out_suffix = "fptemp" if each_model == "acisfp" else each_model
+    model_upper = "FP" if each_model == "acisfp" else each_model.upper()
+
+    # Create the path to the load model output directory
+    out_path = os.path.join(out_dir, f"out_{out_suffix}")
     
-    out_path = os.path.join(out_dir, each_model[1])
     # Now create the command line for executing this model 
-    model_cmd_line = " ".join((ska_bin_base + each_model[0], "--oflsdir", oflsdir, "--out", out_path, "--nlet_file", nlet_file, "--verbose", verbose_val, break_str ))
+    model_cmd_line = " ".join((ska_bin_base + f"{each_model}_check", "--oflsdir", oflsdir, "--out", out_path, "--nlet_file", nlet_file, "--verbose", verbose_val, break_str ))
 
     # Run the model
     results = subprocess.run(model_cmd_line, shell = True)
@@ -230,7 +238,7 @@ for each_model in exec_args:
     # into the appropriate web directory: either the TEST or PRODUCTION directory
 
     # Formulate the web destination
-    web_dir_dest = os.path.join(webroot, each_model[2], load, "ofls" + ver.lower() )
+    web_dir_dest = os.path.join(webroot, f"{prefix}{model_upper}_thermPredic", load, "ofls" + ver.lower() )
    
     # Does the directory exist?
     dir_exist = os.path.isdir(web_dir_dest)

--- a/run_models.py
+++ b/run_models.py
@@ -115,7 +115,7 @@ rmparser.add_argument("--out", type=str,  help="Full path output  directory for 
 rmparser.add_argument("-b", help="If in the command line, specifies if the load is an interrupt load",  action="store_true")
 
 rmparser.add_argument("--nlet_file", type=str, help="Full Path to the Non Load Event Tracking file to be used", default="/data/acis/LoadReviews/NonLoadTrackedEvents.txt" )
-rmparser.add_argument("--verbose",  type=str, help="Indicates verbosity of debug comments", default = 0)
+rmparser.add_argument("--verbose",  type=str, help="Indicates verbosity of debug comments", default = "0")
 
 rmparser.add_argument("-t", help="Flag to allow/prevent writing the out_<model> directories to the web page", action="store_true")
 
@@ -159,12 +159,9 @@ if args.b:
 else:
     break_str = ""
 
-# VERBOSE - Process the verbose switch. If a value was given use it. Otherwise
-# Select minimal verbosity
-if args.verbose:
-    verbose_val = str(args.verbose)
-else:
-    verbose_val = "0"
+# VERBOSE - Process the verbose switch
+verbose_val = args.verbose
+
     
 # TEST - Process the -t switch. This controls whether the files are copied to the production or
 # test web page

--- a/run_models.py
+++ b/run_models.py
@@ -61,7 +61,7 @@ There are a number of changes between this version and the perl version.
                                  - If you supply this path, is is assumed that the backstop file for that load week
                                    has been expanded into this directory and that the directory permissions are such
                                    that the out_* model subdirectories can be created and written into.
-                                          NOTE: If the ACIS backstop history state builder is ued, it is assumed that
+                                          NOTE: If the ACIS backstop history state builder is used, it is assumed that
                                                      all necessary previous load weeks exist using the same base path
                                                      as the present review load.
 

--- a/run_models.py
+++ b/run_models.py
@@ -1,0 +1,247 @@
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+
+"""
+
+ run_models: 
+ 
+ This is a wrapper script that calls the ska thermal models.
+
+This program is the Python replacement of the Perl program run_models.pl
+
+LR calls this program but differentiates between two cases:
+
+   if you use the -T switch with LR, then LR calls run_models with the -out switch
+           - switch argument is the OFLS Directory. 
+           - run_models sets the LR_DIR to the OFLS directory (e.g. TEST_MAY0525)
+           - PREVENTS run_models from copying the resultant files into the web directory
+
+   if you DO NOT use the -T switch with LR, then LR calls run_models without the --out switch.
+          - run_models creates a PRODUCTION ofls directory and uses that 
+   
+
+There are a number of changes between this version and the perl version.
+
+1) No Linux/hostname check
+
+2) The Perl version uses $lr_dir for both the thermal model --oflsdir AND the -out command line switches.  This
+    prevents the user from running a model  on an existing OFLS directory but putting the results elsewhere:
+    which one might do for testing purposes.
+
+    This version has 2 separate command line switches:  --oflsdir and --out and that allows test runs
+    to use an OFLS directory for input without writing into that official OFLS directory. If --out is not
+    supplied, then the output  will be written into the ofls directory.  This is to maintain backward
+    compatibility,
+
+    This means that if you want to put the output files anywhere other than the ofls directory you MUST
+    specify where they should go, withthe path switch.  The Perl version used the $path variable to
+    determine whether or not to copy the plot files to the web for display.  Since we have disassociated path from oflsdir
+    we need another way to prevent copies to the web page.  For that, we use the --web switch.
+
+
+ This program should fail any particular script and continue on if there 
+ is an issue. 
+
+
+  Usage:
+ Specifying a Test Directory:
+ 
+   /data/acis/LoadReviews/script/run_models.pl load_name -h $hostname  ofls_dir break_string -nlet_file $nlet_file 
+
+ Production Run:
+ /data/acis/LoadReviews/script /run_models.py load_name -h $hostname $break_str -nlet_file $nlet_file
+
+ Inputs: load_name - Required. Name of the Review load including letter (e.g. AUG0924A) comes from LR
+
+             oflsdir -   Optional full path to an ofls directory (e.g. /data/acis/LoadReviews/2025/APR2825/oflsa)
+                                 - If you supply this path, is is assumed that the backstop file for that load week
+                                   has been expanded into this directory and that the directory permissions are such
+                                   that the out_* model subdirectories can be created and written into.
+                                          NOTE: If the ACIS backstop history state builder is ued, it is assumed that
+                                                     all necessary previous load weeks exist using the same base path
+                                                     as the present review load.
+
+                             If an OFLS directory is not supplied, the program will formulate one with  /data/acis/LoadReviews
+                             as the base of the path, extract the year and version letter from the load week name. This means
+                             that if you DON'T supply an ofls path then run_models will formulate a path to a PRODUCTION
+                             ofls directory.
+                                  - and if you don't specify the --out switch, run_models will WRITE into that PRODUCTION ofls directory.
+
+                             NOTE: If you are running run_models.py from lr, and use the -T switch on lr, then --out need not be specified 
+                                        and the out_* directories will appear under th eTEST directory.
+
+             out - Optional full, alternate path for the out_* directories. This allows you to run the models
+                     on a production load but not write the output files into the production ofls directory.
+                        - If not specified, the output directory is set to be the same as OFLS dir.
+             
+             b  -  Switch indicating that the load was an interrupt load 
+
+             nlet_file - Full path to the NLET file to be used. (e.g. /data/acis/LoadReviews/NonLoadTrackedEvents.txt)
+                                - The default is the production version
+
+             -t - If true, write the out_<model> subdirectories to the TEST web pages. The default is False to eliminate
+                   the need to specify this switch and maintain backwards compatibility. So if this switch is False, the resultant
+                   output files will be written to the PRODUCTION web pages.
+
+ Here is a truth table for different inputs for --oflsdir and --out:
+
+      -- oflsdir                                 --out                                          --oflsdir                                                   --out
+          input                                   input                                            output                                                  output
+==========================================================================
+           ---                                         ---                         Formulates path to OFLS directory       Formulated path to OFLS directory 
+Path to OFLS directory                    ---                                   Path to OFLS directory                         Path to OFLS directory
+           ---                           Path to output directory     Formulates path to OFLS directory               Path to output directory
+Path to OFLS directory      Path to output directory              Path to OFLS directory                         Path to output directory
+
+   The formulated path to the OFLS directory is:  /data/acis/LoadReviews/<year>/<load>/ofls<version letter>
+   It is based upon the load week and version letter which are  required input.
+
+ Example command line for the 1DPAMZT model:
+
+    /proj/sot/ska3/flight/bin/dpa_check APR2825 --oflsdir  /data/acis/LoadReviews/2025/APR2825/ofls -nlet_file nlet_file "b"
+
+ Initial: August 23, 2024
+           Gregg Germain
+
+"""
+
+# Set up the parser
+rmparser = argparse.ArgumentParser()
+rmparser.add_argument("load_name", help="Name of the Review load including letter (e.g. AUG0924A)")
+rmparser.add_argument("--oflsdir", help="Full path to the OFLS directory of the review load")
+rmparser.add_argument("--out", help="Full path output  directory for the out_* files (e.g. /data/acis/LoadReviews/2025/APR2825/ofls)")
+rmparser.add_argument("-b", help="If in the command line, specifies if the load is an interrupt load",  action="store_true")
+
+rmparser.add_argument("--nlet_file", help="Full Path to the Non Load Event Tracking file to be used", default="/data/acis/LoadReviews/NonLoadTrackedEvents.txt" )
+rmparser.add_argument("--verbose", help="Indicates verbosity of debug comments", default = 0)
+
+rmparser.add_argument("-t", help="Flag to allow/prevents writing the out_<model> directories to the web page", action="store_true")
+
+# Get the arguments
+args = rmparser.parse_args()
+
+# Capture the name of the load.  e.g. DEC0224A
+load_name = args.load_name
+
+# Extract the year and load version letter from the load name
+year = "20"+load_name[5:-1]
+
+# load is the weekly load name without the letter version
+load = load_name[:-1]
+
+# ver is the version letter of the load (e.g. the "A" of AUG1224A)
+ver = load_name[-1]
+
+# OFLSDIR - If the user specified an OFLS directory path then use that one.
+# Otherwise form the usual production path using the year, the load and the version
+if args.oflsdir:
+    # Use the supplied directory
+    oflsdir = args.oflsdir
+else:
+    # Formulate the PRODUCTION directory
+    oflsdir = "/".join(("/data/acis/LoadReviews/" + year, load, "ofls"+ver.lower()))
+
+# OUT - If a --out switch value was supplied, capture it. Otherwise write the output
+# files into the OFLS directory (as you would for production or when you use the -T switch
+# in LR)
+if args.out:
+    # Use the supplied output directory and add to it.
+    out_dir = "/".join((args.out,  "ofls"+ver.lower()))
+else: #...otherwise the output directory is the same as the ofls directory
+    out_dir =  oflsdir
+
+
+# BREAK - Process the load interrupt switch
+if args.b:
+    break_str =  "--interrupt"
+else:
+    break_str = ""
+
+# VERBOSE - Process the verbose switch. If a value was given use it. Otherwise
+# Select minimal verbosity
+if args.verbose:
+    verbose_val = str(args.verbose)
+else:
+    verbose_val = "0"
+    
+# TEST - Process the -t switch. This controls whether the files are copied to the production or
+# test web page
+test_flag = args.t
+    
+# Now set the SKA environment variable for this run
+os.environ["SKA"] = "/proj/sot/ska3/flight"
+
+# Capture the nlet file argument
+nlet_file = args.nlet_file
+
+#---------------------------------------------
+#Set up the ska environment to run
+#---------------------------------------------
+
+ska_bin_base = '/proj/sot/ska3/flight/bin/'
+
+# Argument list for us in formulating the run_models command. Specifies
+# the model name, part of the output directory where resultant files are located,
+# and part of the path where the web copies are located.
+# There r twopossibilities: if you are running for production the web page
+# subdirectory is the Production subdir. Otherwise it's a test directory
+
+# TEST
+if test_flag == True:
+    exec_args = [ ["dpa_check", "out_dpa", "TEST_DPA_thermPredic"],
+                           ["psmc_check",  "out_psmc", "TEST_PSMC_thermPredic"],
+                           ["dpamyt_check", "out_dpamyt", "TEST_DPAMYT_thermPredic"],
+                           ["dea_check", "out_dea", "TEST_DEA_thermPredic"],
+                           ["acisfp_check", "out_fptemp", "TEST_FP_thermPredic"],
+                           ["fep1_mong_check", "out_fep1_mong", "TEST_FEP1_MONG_thermPredic"],
+                           ["fep1_actel_check",  "out_fep1_actel",  "TEST_FEP1_ACTEL_thermPredic"],
+                           ["bep_pcb_check", "out_bep_pcb", "TEST_BEP_PCB_thermPredic"]]
+else:
+    exec_args = [ ["dpa_check", "out_dpa", "DPA_thermPredic"],
+                           ["psmc_check",  "out_psmc", "PSMC_thermPredic"],
+                           ["dpamyt_check", "out_dpamyt", "DPAMYT_thermPredic"],
+                           ["dea_check", "out_dea", "DEA_thermPredic"],
+                           ["acisfp_check", "out_fptemp", "FP_thermPredic"],
+                           ["fep1_mong_check", "out_fep1_mong", "FEP1_MONG_thermPredic"],
+                           ["fep1_actel_check",  "out_fep1_actel",  "FEP1_ACTEL_thermPredic"],
+                           ["bep_pcb_check", "out_bep_pcb", "BEP_PCB_thermPredic"] ]
+
+
+# Specify the base web directory
+webroot = "/proj/web-cxc/htdocs/acis"
+
+# Now run each model and create the web directory for the output files, and copy
+# the files into that directory
+#
+for each_model in exec_args:
+    print("\nExecuting model: ", each_model[0])
+    sys.stdout.flush()
+    
+    out_path = "/".join((out_dir, each_model[1]))
+    # Now create the command line for executing this model 
+    model_cmd_line = " ".join((ska_bin_base + each_model[0], "--oflsdir", oflsdir, "--out", out_path, "--nlet_file", nlet_file, "--verbose", verbose_val, break_str ))
+
+    # Run the model
+    results = subprocess.run(model_cmd_line, shell = True)
+
+    # Next  copy the contents of the oflsdir out_<model> directories
+    # into the appropriate web directory: either the TEST or PRODUCTION directory
+
+    # Formulate the web destination
+    web_dir_dest = "/".join((webroot, each_model[2], load, "ofls" + ver.lower(), each_model[1] ))
+   
+    # Does the directory exist?
+    dir_exist = os.path.isdir(web_dir_dest)
+
+    # Create the directory if it doesn't exist
+    if dir_exist == False:
+        os.makedirs(web_dir_dest, exist_ok=True)
+
+    # Copy each file in the directory
+    for item in os.listdir(out_path):
+        shutil.copy2("/".join((out_path, item)), web_dir_dest)
+        


### PR DESCRIPTION

lr is the ACIS Operations  review load processing program. Updates were made to lr and to several of the
other programs lr executes.

lr, itself, was modified to fix an IF statement that incorrectly analyzed if a load was of the type TOO and the
continuity load is Vehicle Only. lr was also  modified to call the new run_models.py which replaces run_models.pl

The following updated programs are excuted by lr:

run_models.py was written to continue the conversion of load review programs from Perl to Python. run_models.py included
a new switch allowing for easier unit testing on existing Production loads.  No interface changes.

acisbackstop.pl was modified to eliminate false errors generated when calculating the time delta
between an observation's Stop Science command and the next command to change the Obsid.

Check_Power_Cmds.py was modified to be more efficient by avoiding the ACISPKT processing loop when processing a
Vehicle Only load.

Other updates includes fixing typos and making comments more clear.

